### PR TITLE
Add automation

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,42 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["develop"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["develop"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vision-api-swagger-ui
 
-API documentation for Skintelligent's vision API. 
+API documentation for Skintelligent's vision API. The webpage is available at https://skintelligent-lab.github.io/vision-api-swagger-ui/
 
 The API documentation is contained in `static/spec`; these files are automatically built and pushed to this repo during builds of the [vision API](https://github.com/Skintelligent-Lab/vision-api). The boilerplate HTML/JS is copied from [this repo](https://github.com/peter-evans/swagger-github-pages). The root document for the OpenAPI specification (currently `static/spec/openapi.yaml`) is controlled by the `url` argument to the `SwaggerUIBundle` constructor in the file `static/swagger-initializer.js`.
 

--- a/static/spec/openapi.yaml
+++ b/static/spec/openapi.yaml
@@ -11,8 +11,8 @@ info:
   contact:
     name: Brian Keating
     email: brian@skintelligentlab.com
-  license:
-    name: Proprietary to Skintelligent. All rights reserved
+  # license:
+  #   name: Proprietary to Skintelligent. All rights reserved
 
 components:
   securitySchemes:


### PR DESCRIPTION
For some reason, just pushing to `main` and selecting the "Deploy from a Branch" in the GH Pages Settings did not work (I was getting a 404). Apparently, using the suggested GH Actions successfully publishes the page. I don't get it.